### PR TITLE
Set a timeout for JSON schema request.

### DIFF
--- a/rules/core.py
+++ b/rules/core.py
@@ -264,7 +264,7 @@ def getJsonSchemaFromObject(rule_args, callback, rei):
         requests_cache.install_cache('/tmp/irods_avu_json-ruleset-cache', backend='sqlite', expire_after=60 * 60 * 24)
 
         try:
-            r = requests.get(json_schema_url)
+            r = requests.get(json_schema_url, timeout=30)
         except requests.exceptions.RequestException as e:  # This is the correct syntax
             callback.msiExit("-1101000", "JSON schema could not be downloaded : " + str(e.message))
             return


### PR DESCRIPTION
By default, requests calls wait until the connection is closed.  A requests call without a timeout will hang the program if a response is never received. Setting timeout to 30 seconds.
